### PR TITLE
Link ros-net-sim submodule to new location

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "ros-net-sim"]
 	path = ros-net-sim
-	url = https://github.com/tylerferrara/ros-net-sim.git
+	url = https://github.com/NESTLab/ros-net-sim.git
+	branch = main
 [submodule "argos_bridge"]
 	path = argos_bridge
 	url = https://github.com/nikopoulospet/argos_bridge.git


### PR DESCRIPTION
ros-net-sim now belongs to the NESTLab org